### PR TITLE
DN7630 enable html signatures for eml files

### DIFF
--- a/modules/signatures/all/credential_access_phishingkit.py
+++ b/modules/signatures/all/credential_access_phishingkit.py
@@ -37,7 +37,7 @@ class HTMLPhisher_0(Signature):
     ttps += ["T1566.001"]  # MITRE v6,7,8
     ttps += ["T1606"]  # MITRE v7,8
     mbcs = ["C0029.003"]  # micro-behaviour
-    packages = ["html", "edge", "chrome", "firefox"]
+    packages = ["html", "edge", "chrome", "firefox", "eml"]
 
     def run(self):
         has_match = False
@@ -86,7 +86,7 @@ class HTMLPhisher_1(Signature):
     ttps += ["T1566.001"]  # MITRE v6,7,8
     ttps += ["T1606"]  # MITRE v7,8
     mbcs = ["C0029.003"]  # micro-behaviour
-    packages = ["html", "edge", "chrome", "firefox"]
+    packages = ["html", "edge", "chrome", "firefox", "eml"]
 
     def run(self):
         has_match = False
@@ -146,7 +146,7 @@ class HTMLPhisher_2(Signature):
 
     def run(self):
         has_match = False
-        packages = ["html", "edge", "chrome", "firefox"]
+        packages = ["html", "edge", "chrome", "firefox", "eml"]
 
         if self.results["info"]["package"] in packages:
             strings = self.results["target"]["file"]["strings"]

--- a/modules/signatures/all/suspicious_html.py
+++ b/modules/signatures/all/suspicious_html.py
@@ -36,7 +36,7 @@ class suspiciousHRML_Body(Signature):
     mbcs = ["C0029.003"]  # micro-behaviour
 
     def run(self):
-        packages = ["html", "edge", "chrome", "firefox"]
+        packages = ["html", "edge", "chrome", "firefox", "eml"]
         indicators = [
             "encoded_string",
             "// remove email, and put ur mailer code",
@@ -84,7 +84,7 @@ class suspiciousHTML_Title(Signature):
 
     def run(self):
 
-        packages = ["html", "edge", "chrome", "firefox"]
+        packages = ["html", "edge", "chrome", "firefox", "eml"]
         indicators = [
             "Please wait",
             "Sign in",
@@ -129,7 +129,7 @@ class suspiciousHTML_Filename(Signature):
     mbcs = ["C0029.003"]  # micro-behaviour
 
     def run(self):
-        packages = ["html", "edge", "chrome", "firefox"]
+        packages = ["html", "edge", "chrome", "firefox", "eml"]
         indicators = [
             "payment",
             "remittence",


### PR DESCRIPTION
These will be helpful in eml analysis as they usually contain html.